### PR TITLE
support =/X CIGAR operators

### DIFF
--- a/PerlLib/SAM_entry.pm
+++ b/PerlLib/SAM_entry.pm
@@ -204,19 +204,18 @@ sub get_alignment_coords {
     my $sum_hardmasked_query = 0;
 
 	$genome_lend--; # move pointer just before first position.
-	
-	while ($alignment =~ /(\d+)([A-Z])/g) {
+	 
+	while ($alignment =~ /(\d+)([A-Z=])/g) {
 		my $len = $1;
 		my $code = $2;
-		
-		unless ($code =~ /^[MSDNIH]$/) {
+		 
+		unless ($code =~ /^[MSDNIH=X]$/) {
 			confess "Error, cannot parse cigar code [$code] " . $self->toString();
 		}
 		
 		# print "parsed $len,$code\n";
 		
-		if ($code eq 'M') { # aligned bases match or mismatch
-			
+		if  ($code =~ /^[M=X]$/){ # aligned bases match or mismatch			
 			my $genome_rend = $genome_lend + $len;
 			my $query_rend = $query_lend + $len;
 			


### PR DESCRIPTION
Modified 3 lines of code in `PerlLib/SAM_entry.pm` and  `FusionInspector/PerlLib/SAM_entry.pm` to recognise =/X CIGAR operators for match and mismatch, respectively, as generated through the application of `--eqx` flag in minimap2. 

Changes were tested by pulling `docker://trinityctat/ctat_lr_fusion:1.3.0`, extracting the scripts, making local changes, and rebuilding them into the local image. 

It would be great if you could test these changes more thoroughly and include this extended CIGAR support in the next version :-) 



